### PR TITLE
Add the ability to configure hazelcast under okapi

### DIFF
--- a/okapi/Chart.yaml
+++ b/okapi/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: okapi
 description: A Helm chart OKAPI for Kubernetes
 
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.28
+version: 0.3.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/okapi/templates/NOTES.txt
+++ b/okapi/templates/NOTES.txt
@@ -19,3 +19,40 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
 {{- end }}
+{{- if .Values.hazelcast.enabled }}
+{{- if not .Values.hazelcast.clusterRole }}
+
+You requested hazelcast configuration but not to create the hazelcast
+ClusterRole.  You'll need to have a kubernetes system administrator manually do
+so if you haven't yet.  Here is what would have been applied, to send to them:
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hazelcast-view-nodes
+rules:
+- apiGroups:
+  - ""
+  resources: ["nodes"]
+  verbs:
+  - get
+  - list
+  - watch
+---
+{{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  name: hazelcast-view-nodes-binding
+roleRef:
+  kind: ClusterRole
+  name: hazelcast-view-nodes
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "okapi.serviceAccountName" . }}
+{{- end }}
+{{- end }}

--- a/okapi/templates/deployment.yaml
+++ b/okapi/templates/deployment.yaml
@@ -35,7 +35,20 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - {{ .Values.args }}
+            {{- if .Values.hazelcast.enabled }}
+            {{- range .Values.hazelcast.args }}
+            - {{ . | quote }}
+            {{- end }}
+            {{- end }}
           env:
+            - name: OKAPI_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OKAPI_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: OKAPI_HOST
               valueFrom:
                 secretKeyRef:
@@ -57,7 +70,11 @@ spec:
                   name: db-connect-modules
                   key: DB_PASSWORD
             - name: JAVA_OPTIONS
+              {{- if .Values.hazelcast.enabled }}
+              value: {{ cat .Values.javaOptions .Values.hazelcast.javaOptions | quote }}
+              {{- else }}
               value: {{ .Values.javaOptions | quote }}
+              {{- end }}
           ports:
             - name: http
               containerPort: 9130
@@ -67,12 +84,25 @@ spec:
             readOnly: true
             mountPath: "/etc/log4j2.xml"
             subPath: "log4j2.xml"
+          {{- if .Values.hazelcast.enabled }}
+          - name: "hazelcast"
+            readOnly: true
+            mountPath: "/hazelcast/hazelcast.xml"
+            subPath: hazelcast.xml
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
       - name: "log4j2-xml"
         configMap:
           name: okapi-log4j2-configmap
+      {{- if .Values.hazelcast.enabled }}
+      - name: "hazelcast"
+        configMap:
+          defaultMode: 420
+          name: {{ include "okapi.fullname" . }}-hazelcast-configmap
+          optional: false
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/okapi/templates/okapi-hazelcast-configmap.yml
+++ b/okapi/templates/okapi-hazelcast-configmap.yml
@@ -1,0 +1,245 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "okapi.fullname" . }}-hazelcast-configmap
+data:
+  hazelcast.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.hazelcast.com/schema/config
+               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+        <cluster-name>cluster</cluster-name>
+        <network>
+            <port auto-increment="true" port-count="100">5701</port>
+            <outbound-ports>
+                <ports>0</ports>
+            </outbound-ports>
+            <join>
+                <multicast enabled="false"></multicast>
+                <tcp-ip enabled="false"></tcp-ip>
+                <aws enabled="false"></aws>
+                <gcp enabled="false"></gcp>
+                <azure enabled="false"></azure>
+                <kubernetes enabled="true">
+                    <namespace>{{ .Release.Namespace }}</namespace>
+                    <service-name>{{ include "okapi.serviceAccountName" . }}</service-name>
+                </kubernetes>
+                <eureka enabled="false"></eureka>
+                <discovery-strategies>
+                </discovery-strategies>
+            </join>
+            <interfaces enabled="false">
+                <interface>10.10.1.*</interface>
+            </interfaces>
+            <ssl enabled="false"/>
+            <socket-interceptor enabled="false"/>
+            <symmetric-encryption enabled="false">
+                <!--
+                   encryption algorithm such as
+                   DES/ECB/PKCS5Padding,
+                   PBEWithMD5AndDES,
+                   AES/CBC/PKCS5Padding,
+                   Blowfish,
+                   DESede
+                -->
+                <algorithm>PBEWithMD5AndDES</algorithm>
+                <!-- salt value to use when generating the secret key -->
+                <salt>thesalt</salt>
+                <!-- pass phrase to use when generating the secret key -->
+                <password>thepass</password>
+                <!-- iteration count to use when generating the secret key -->
+                <iteration-count>19</iteration-count>
+            </symmetric-encryption>
+            <failure-detector>
+                <icmp enabled="false"/>
+            </failure-detector>
+        </network>
+        <partition-group enabled="false"/>
+        <executor-service name="default">
+            <pool-size>16</pool-size>
+            <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+            <queue-capacity>0</queue-capacity>
+        </executor-service>
+        <security>
+            <client-block-unmapped-actions>true</client-block-unmapped-actions>
+        </security>
+        <queue name="default">
+            <!--
+                Maximum size of the queue. When a JVM's local queue size reaches the maximum,
+                all put/offer operations will get blocked until the queue size
+                of the JVM goes down below the maximum.
+                Any integer between 0 and Integer.MAX_VALUE. 0 means
+                Integer.MAX_VALUE. Default is 0.
+            -->
+            <max-size>0</max-size>
+            <!--
+                Number of backups. If 1 is set as the backup-count for example,
+                then all entries of the map will be copied to another JVM for
+                fail-safety. 0 means no backup.
+            -->
+            <backup-count>1</backup-count>
+            <!--
+                Number of async backups. 0 means no backup.
+            -->
+            <async-backup-count>0</async-backup-count>
+            <empty-queue-ttl>-1</empty-queue-ttl>
+            <merge-policy batch-size="100">com.hazelcast.spi.merge.PutIfAbsentMergePolicy</merge-policy>
+        </queue>
+        <map name="default">
+            <!--
+               Data type that will be used for storing recordMap.
+               Possible values:
+               BINARY (default): keys and values will be stored as binary data
+               OBJECT : values will be stored in their object forms
+               NATIVE : values will be stored in non-heap region of JVM
+            -->
+            <in-memory-format>BINARY</in-memory-format>
+            <!--
+                Metadata creation policy for this map. Hazelcast may process objects of supported types ahead of time to
+                create additional metadata about them. This metadata then is used to make querying and indexing faster.
+                Metadata creation may decrease put throughput.
+                Valid values are:
+                CREATE_ON_UPDATE (default): Objects of supported types are pre-processed when they are created and updated.
+                OFF: No metadata is created.
+            -->
+            <metadata-policy>CREATE_ON_UPDATE</metadata-policy>
+            <!--
+                Number of backups. If 1 is set as the backup-count for example,
+                then all entries of the map will be copied to another JVM for
+                fail-safety. 0 means no backup.
+            -->
+            <backup-count>1</backup-count>
+            <!--
+                Number of async backups. 0 means no backup.
+            -->
+            <async-backup-count>0</async-backup-count>
+            <!--
+                Maximum number of seconds for each entry to stay in the map. Entries that are
+                older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+                will get automatically evicted from the map.
+                Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0
+            -->
+            <time-to-live-seconds>0</time-to-live-seconds>
+            <!--
+                Maximum number of seconds for each entry to stay idle in the map. Entries that are
+                idle(not touched) for more than <max-idle-seconds> will get
+                automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+                Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+            -->
+            <max-idle-seconds>0</max-idle-seconds>
+            <eviction eviction-policy="NONE" max-size-policy="PER_NODE" size="0"/>
+            <!--
+                While recovering from split-brain (network partitioning),
+                map entries in the small cluster will merge into the bigger cluster
+                based on the policy set here. When an entry merge into the
+                cluster, there might an existing entry with the same key already.
+                Values of these entries might be different for that same key.
+                Which value should be set for the key? Conflict is resolved by
+                the policy set here. Default policy is PutIfAbsentMapMergePolicy
+                There are built-in merge policies such as
+                com.hazelcast.spi.merge.PassThroughMergePolicy; entry will be overwritten if merging entry exists for the key.
+                com.hazelcast.spi.merge.PutIfAbsentMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+                com.hazelcast.spi.merge.HigherHitsMergePolicy ; entry with the higher hits wins.
+                com.hazelcast.spi.merge.LatestUpdateMergePolicy ; entry with the latest update wins.
+            -->
+            <merge-policy batch-size="100">com.hazelcast.spi.merge.PutIfAbsentMergePolicy</merge-policy>
+            <!--
+               Control caching of de-serialized values. Caching makes query evaluation faster, but it cost memory.
+               Possible Values:
+                            NEVER: Never cache deserialized object
+                            INDEX-ONLY: Caches values only when they are inserted into an index.
+                            ALWAYS: Always cache deserialized values.
+            -->
+            <cache-deserialized-values>INDEX-ONLY</cache-deserialized-values>
+        </map>
+        <multimap name="default">
+            <backup-count>1</backup-count>
+            <value-collection-type>SET</value-collection-type>
+            <merge-policy batch-size="100">com.hazelcast.spi.merge.PutIfAbsentMergePolicy</merge-policy>
+        </multimap>
+        <replicatedmap name="default">
+            <in-memory-format>OBJECT</in-memory-format>
+            <async-fillup>true</async-fillup>
+            <statistics-enabled>true</statistics-enabled>
+            <merge-policy batch-size="100">com.hazelcast.spi.merge.PutIfAbsentMergePolicy</merge-policy>
+        </replicatedmap>
+        <list name="default">
+            <backup-count>1</backup-count>
+            <merge-policy batch-size="100">com.hazelcast.spi.merge.PutIfAbsentMergePolicy</merge-policy>
+        </list>
+        <set name="default">
+            <backup-count>1</backup-count>
+            <merge-policy batch-size="100">com.hazelcast.spi.merge.PutIfAbsentMergePolicy</merge-policy>
+        </set>
+        <reliable-topic name="default">
+            <read-batch-size>10</read-batch-size>
+            <topic-overload-policy>BLOCK</topic-overload-policy>
+            <statistics-enabled>true</statistics-enabled>
+        </reliable-topic>
+        <ringbuffer name="default">
+            <capacity>10000</capacity>
+            <backup-count>1</backup-count>
+            <async-backup-count>0</async-backup-count>
+            <time-to-live-seconds>0</time-to-live-seconds>
+            <in-memory-format>BINARY</in-memory-format>
+            <merge-policy batch-size="100">com.hazelcast.spi.merge.PutIfAbsentMergePolicy</merge-policy>
+        </ringbuffer>
+        <flake-id-generator name="default">
+            <prefetch-count>100</prefetch-count>
+            <prefetch-validity-millis>600000</prefetch-validity-millis>
+            <epoch-start>1514764800000</epoch-start>
+            <node-id-offset>0</node-id-offset>
+            <bits-sequence>6</bits-sequence>
+            <bits-node-id>16</bits-node-id>
+            <allowed-future-millis>15000</allowed-future-millis>
+            <statistics-enabled>true</statistics-enabled>
+        </flake-id-generator>
+        <serialization>
+            <portable-version>0</portable-version>
+        </serialization>
+        <lite-member enabled="false"/>
+        <cardinality-estimator name="default">
+            <backup-count>1</backup-count>
+            <async-backup-count>0</async-backup-count>
+            <merge-policy batch-size="100">HyperLogLogMergePolicy</merge-policy>
+        </cardinality-estimator>
+        <scheduled-executor-service name="default">
+            <capacity>100</capacity>
+            <durability>1</durability>
+            <pool-size>16</pool-size>
+            <merge-policy batch-size="100">com.hazelcast.spi.merge.PutIfAbsentMergePolicy</merge-policy>
+        </scheduled-executor-service>
+        <crdt-replication>
+            <replication-period-millis>1000</replication-period-millis>
+            <max-concurrent-replication-targets>1</max-concurrent-replication-targets>
+        </crdt-replication>
+        <pn-counter name="default">
+            <replica-count>2147483647</replica-count>
+            <statistics-enabled>true</statistics-enabled>
+        </pn-counter>
+        <cp-subsystem>
+            <cp-member-count>0</cp-member-count>
+            <group-size>0</group-size>
+            <session-time-to-live-seconds>300</session-time-to-live-seconds>
+            <session-heartbeat-interval-seconds>5</session-heartbeat-interval-seconds>
+            <missing-cp-member-auto-removal-seconds>14400</missing-cp-member-auto-removal-seconds>
+            <fail-on-indeterminate-operation-state>false</fail-on-indeterminate-operation-state>
+            <raft-algorithm>
+                <leader-election-timeout-in-millis>2000</leader-election-timeout-in-millis>
+                <leader-heartbeat-period-in-millis>5000</leader-heartbeat-period-in-millis>
+                <max-missed-leader-heartbeat-count>5</max-missed-leader-heartbeat-count>
+                <append-request-max-entry-count>100</append-request-max-entry-count>
+                <commit-index-advance-count-to-snapshot>10000</commit-index-advance-count-to-snapshot>
+                <uncommitted-entry-count-to-reject-new-appends>100</uncommitted-entry-count-to-reject-new-appends>
+                <append-request-backoff-timeout-in-millis>100</append-request-backoff-timeout-in-millis>
+            </raft-algorithm>
+        </cp-subsystem>
+        <metrics enabled="true">
+            <management-center enabled="true">
+                <retention-seconds>5</retention-seconds>
+            </management-center>
+            <jmx enabled="true"/>
+            <collection-frequency-seconds>5</collection-frequency-seconds>
+        </metrics>
+    </hazelcast>

--- a/okapi/templates/service.yaml
+++ b/okapi/templates/service.yaml
@@ -15,5 +15,16 @@ spec:
       targetPort: {{ .Values.service.containerPort }}
       protocol: TCP
       name: http
+    {{- if .Values.hazelcast.enabled }}
+    - port: 5701
+      name: hazelcast-5701
+      protocol: TCP
+    - port: 5704
+      name: hazelcast-5704
+      protocol: TCP
+    - port: 54327
+      name: multicast
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "okapi.selectorLabels" . | nindent 4 }}

--- a/okapi/templates/serviceaccount.yaml
+++ b/okapi/templates/serviceaccount.yaml
@@ -9,4 +9,90 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{ if .Values.hazelcast.enabled -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hazelcast-view
+  labels:
+    {{- include "okapi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+  - ""
+  resources: ["endpoints", "pods", "services"]
+  verbs:
+  - get
+  - list
+  - watch
+---
+{{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+kind: RoleBinding
+metadata:
+  name: hazelcast-view-binding
+  labels:
+    {{- include "okapi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  kind: Role
+  name: hazelcast-view
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "okapi.serviceAccountName" . }}
+{{ if .Values.hazelcast.clusterRole -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hazelcast-view-nodes
+  labels:
+    {{- include "okapi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+  - ""
+  resources: ["nodes"]
+  verbs:
+  - get
+  - list
+  - watch
+---
+{{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  name: hazelcast-view-nodes-binding
+  labels:
+    {{- include "okapi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  kind: ClusterRole
+  name: hazelcast-view-nodes
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "okapi.serviceAccountName" . }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/okapi/values.yaml
+++ b/okapi/values.yaml
@@ -82,9 +82,46 @@ tolerations: []
 
 affinity: {}
 
+# Whether to enable hazelcast kubernetes negotiation for high-availability
+# memory sharing, and arguments and java options to add to the regular args
+# and javaOptions if so.
+hazelcast:
+  enabled: false
+  # You'll need to set a clusterrole for hazelcast to access node status, but
+  # users may not have access to do so without a cluster admin.
+  clusterRole: true
+  args:
+    - -cluster-host
+    - $(OKAPI_POD_IP)
+    - -cluster-port
+    - 5702
+    - -hazelcast-config-file
+    - /hazelcast/hazelcast.xml
+  javaOptions: >-
+    -Dhazelcast.ip=$(OKAPI_SERVICE_HOST)
+    -Dhazelcast.port=5701
+    -Dnodename=$(OKAPI_POD_NAME)
+    --add-modules java.se
+    --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+    --add-opens java.base/java.lang=ALL-UNNAMED
+    --add-opens java.base/java.nio=ALL-UNNAMED
+    --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+    --add-opens java.management/sun.management=ALL-UNNAMED 
+    --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+
 # Folio specific
 args: dev
-javaOptions: -Djava.awt.headless=true -Dstorage=postgres -Dpostgres_host=$(OKAPI_HOST) -Dpostgres_port=5432 -Dpostgres_username=$(OKAPI_DB_USER) -Dpostgres_password=$(OKAPI_DB_PASSWORD) -Dpostgres_database=$(OKAPI_DB) -Dlog4j.configurationFile=/etc/log4j2.xml -Dhost=okapi -Dokapiurl=http://okapi:9130
+javaOptions: >-
+  -Djava.awt.headless=true
+  -Dstorage=postgres
+  -Dpostgres_host=$(OKAPI_HOST)
+  -Dpostgres_port=5432
+  -Dpostgres_username=$(OKAPI_DB_USER)
+  -Dpostgres_password=$(OKAPI_DB_PASSWORD)
+  -Dpostgres_database=$(OKAPI_DB)
+  -Dlog4j.configurationFile=/etc/log4j2.xml
+  -Dhost=okapi
+  -Dokapiurl=http://okapi:9130
 
 postJob:
   enabled: false


### PR DESCRIPTION
This adds options to set up hazelcast in order to provide memory sharing
across okapi pods for high availability.  Some of the functionality
requires creating a clusterrole, which end users might not have access
to do.  In that case there's an option to only set up the local role and
print out the clusterrole to send to your k8s administrators.