### PR TITLE
Fix log4j security vulnerability

### DIFF
--- a/edge-caiasoft/values.yaml
+++ b/edge-caiasoft/values.yaml
@@ -39,7 +39,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
-  containerPort: 8081  
+  containerPort: 8081
 
 ingress:
   enabled: false
@@ -79,5 +79,5 @@ tolerations: []
 
 affinity: {}
 
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5

--- a/edge-connexion/values.yaml
+++ b/edge-connexion/values.yaml
@@ -82,5 +82,5 @@ tolerations: []
 
 affinity: {}
 
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5

--- a/edge-dematic/values.yaml
+++ b/edge-dematic/values.yaml
@@ -79,5 +79,5 @@ tolerations: []
 
 affinity: {}
 
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5

--- a/edge-ea-data-export/values.yaml
+++ b/edge-ea-data-export/values.yaml
@@ -79,5 +79,5 @@ tolerations: []
 
 affinity: {}
 
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5

--- a/edge-inn-reach/values.yaml
+++ b/edge-inn-reach/values.yaml
@@ -43,20 +43,20 @@ service:
 
 ingress:
   enabled: false
-  annotations: 
+  annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
   hosts:
-    - host: 
+    - host:
       paths: []
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
-resources: 
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -82,5 +82,5 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dsecure_store_props=/etc/edge/ephemeral.properties -Dokapi_url=http://okapi:9130
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dsecure_store_props=/etc/edge/ephemeral.properties -Dokapi_url=http://okapi:9130
 dbMaxPoolSize: 5

--- a/edge-ncip/values.yaml
+++ b/edge-ncip/values.yaml
@@ -79,5 +79,5 @@ tolerations: []
 
 affinity: {}
 
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5

--- a/edge-oai-pmh/values.yaml
+++ b/edge-oai-pmh/values.yaml
@@ -81,5 +81,5 @@ tolerations: []
 
 affinity: {}
 
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dokapi_url=http://okapi:9130 -Dsecure_store_props=/etc/edge/ephemeral.properties
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dokapi_url=http://okapi:9130 -Dsecure_store_props=/etc/edge/ephemeral.properties
 dbMaxPoolSize: 5

--- a/edge-orders/values.yaml
+++ b/edge-orders/values.yaml
@@ -79,5 +79,5 @@ tolerations: []
 
 affinity: {}
 
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dokapi_url=http://okapi:9130 -Dsecure_store_props=/etc/edge/ephemeral/ephemeral.properties -Dapi_config=/etc/edge/api/api_configuration.json
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dokapi_url=http://okapi:9130 -Dsecure_store_props=/etc/edge/ephemeral/ephemeral.properties -Dapi_config=/etc/edge/api/api_configuration.json
 dbMaxPoolSize: 5

--- a/edge-patron/values.yaml
+++ b/edge-patron/values.yaml
@@ -79,5 +79,5 @@ tolerations: []
 
 affinity: {}
 
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5

--- a/edge-rtac/values.yaml
+++ b/edge-rtac/values.yaml
@@ -79,5 +79,5 @@ tolerations: []
 
 affinity: {}
 
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dokapi_url=http://okapi:9130 -Dsecure_store_props=/etc/edge/ephemeral.properties
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dokapi_url=http://okapi:9130 -Dsecure_store_props=/etc/edge/ephemeral.properties
 dbMaxPoolSize: 5

--- a/edge-sip2/values.yaml
+++ b/edge-sip2/values.yaml
@@ -79,5 +79,5 @@ tolerations: []
 
 affinity: {}
 
-javaOptions: -XX:MaxRAMPercentage=80.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=80.0 -XX:+UseG1GC
 dbMaxPoolSize: 5

--- a/mod-aes/values.yaml
+++ b/mod-aes/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-agreements/values.yaml
+++ b/mod-agreements/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-audit/values.yaml
+++ b/mod-audit/values.yaml
@@ -39,7 +39,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
-  containerPort: 8081  
+  containerPort: 8081
 
 ingress:
   enabled: false
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-authtoken/values.yaml
+++ b/mod-authtoken/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dcache.permissions=true -Djwt.signing.key=$(JWT_SIGNING_KEY)
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dcache.permissions=true -Djwt.signing.key=$(JWT_SIGNING_KEY)
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-calendar/values.yaml
+++ b/mod-calendar/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-circulation-storage/values.yaml
+++ b/mod-circulation-storage/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-circulation/values.yaml
+++ b/mod-circulation/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-codex-ekb/values.yaml
+++ b/mod-codex-ekb/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-codex-inventory/values.yaml
+++ b/mod-codex-inventory/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-codex-mux/values.yaml
+++ b/mod-codex-mux/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-configuration/values.yaml
+++ b/mod-configuration/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-copycat/values.yaml
+++ b/mod-copycat/values.yaml
@@ -84,7 +84,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-courses/values.yaml
+++ b/mod-courses/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-data-export-spring/values.yaml
+++ b/mod-data-export-spring/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-data-export-worker/values.yaml
+++ b/mod-data-export-worker/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-data-export/values.yaml
+++ b/mod-data-export/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Daws.region=$(AWS_REGION) -Daws.accessKeyId=$(AWS_ACCESS_KEY_ID) -Daws.secretKey=$(AWS_SECRET_ACCESS_KEY) -Dbucket.name=$(AWS_BUCKET)
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Daws.region=$(AWS_REGION) -Daws.accessKeyId=$(AWS_ACCESS_KEY_ID) -Daws.secretKey=$(AWS_SECRET_ACCESS_KEY) -Dbucket.name=$(AWS_BUCKET)
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-data-import-converter-storage/values.yaml
+++ b/mod-data-import-converter-storage/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-data-import/values.yaml
+++ b/mod-data-import/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-ebsconet/values.yaml
+++ b/mod-ebsconet/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-email/values.yaml
+++ b/mod-email/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-erm-usage-harvester/values.yaml
+++ b/mod-erm-usage-harvester/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-erm-usage/values.yaml
+++ b/mod-erm-usage/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-eusage-reports/values.yaml
+++ b/mod-eusage-reports/values.yaml
@@ -54,7 +54,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: 
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-event-config/values.yaml
+++ b/mod-event-config/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-feesfines/values.yaml
+++ b/mod-feesfines/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-finance-storage/values.yaml
+++ b/mod-finance-storage/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-finance/values.yaml
+++ b/mod-finance/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-gobi/values.yaml
+++ b/mod-gobi/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-graphql/values.yaml
+++ b/mod-graphql/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-inn-reach/values.yaml
+++ b/mod-inn-reach/values.yaml
@@ -84,7 +84,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-inventory-storage/values.yaml
+++ b/mod-inventory-storage/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-inventory/values.yaml
+++ b/mod-inventory/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dorg.folio.metadata.inventory.storage.type=okapi
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dorg.folio.metadata.inventory.storage.type=okapi
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-invoice-storage/values.yaml
+++ b/mod-invoice-storage/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-invoice/values.yaml
+++ b/mod-invoice/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-kb-ebsco-java/values.yaml
+++ b/mod-kb-ebsco-java/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-ldp/values.yaml
+++ b/mod-ldp/values.yaml
@@ -81,7 +81,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-licenses/values.yaml
+++ b/mod-licenses/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-login-saml/values.yaml
+++ b/mod-login-saml/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-login/values.yaml
+++ b/mod-login/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-marccat/values.yaml
+++ b/mod-marccat/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-ncip/values.yaml
+++ b/mod-ncip/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-notes/values.yaml
+++ b/mod-notes/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-notify/values.yaml
+++ b/mod-notify/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-oai-pmh/values.yaml
+++ b/mod-oai-pmh/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-orders-storage/values.yaml
+++ b/mod-orders-storage/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-orders/values.yaml
+++ b/mod-orders/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-organizations-storage/values.yaml
+++ b/mod-organizations-storage/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-organizations/values.yaml
+++ b/mod-organizations/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-password-validator/values.yaml
+++ b/mod-password-validator/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-patron-blocks/values.yaml
+++ b/mod-patron-blocks/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-patron/values.yaml
+++ b/mod-patron/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-permissions/values.yaml
+++ b/mod-permissions/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-pubsub/values.yaml
+++ b/mod-pubsub/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-quick-marc/values.yaml
+++ b/mod-quick-marc/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-rtac/values.yaml
+++ b/mod-rtac/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-search/values.yaml
+++ b/mod-search/values.yaml
@@ -82,7 +82,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-sender/values.yaml
+++ b/mod-sender/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-service-interaction/values.yaml
+++ b/mod-service-interaction/values.yaml
@@ -54,7 +54,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: 
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-source-record-manager/values.yaml
+++ b/mod-source-record-manager/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-source-record-storage/values.yaml
+++ b/mod-source-record-storage/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-tags/values.yaml
+++ b/mod-tags/values.yaml
@@ -81,7 +81,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-template-engine/values.yaml
+++ b/mod-template-engine/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-user-import/values.yaml
+++ b/mod-user-import/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-users-bl/values.yaml
+++ b/mod-users-bl/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-users/values.yaml
+++ b/mod-users/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/mod-z3950/values.yaml
+++ b/mod-z3950/values.yaml
@@ -83,7 +83,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
+javaOptions: -Dlog4j2.formatMsgNoLookups=true  -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC
 dbMaxPoolSize: 5
 
 postJob:

--- a/okapi/values.yaml
+++ b/okapi/values.yaml
@@ -97,7 +97,7 @@ hazelcast:
     - 5702
     - -hazelcast-config-file
     - /hazelcast/hazelcast.xml
-  javaOptions: -Dlog4j2.formatMsgNoLookups=true  >-
+  javaOptions: >-
     -Dhazelcast.ip=$(OKAPI_SERVICE_HOST)
     -Dhazelcast.port=5701
     -Dnodename=$(OKAPI_POD_NAME)

--- a/okapi/values.yaml
+++ b/okapi/values.yaml
@@ -97,7 +97,7 @@ hazelcast:
     - 5702
     - -hazelcast-config-file
     - /hazelcast/hazelcast.xml
-  javaOptions: >-
+  javaOptions: -Dlog4j2.formatMsgNoLookups=true  >-
     -Dhazelcast.ip=$(OKAPI_SERVICE_HOST)
     -Dhazelcast.port=5701
     -Dnodename=$(OKAPI_POD_NAME)
@@ -106,7 +106,7 @@ hazelcast:
     --add-opens java.base/java.lang=ALL-UNNAMED
     --add-opens java.base/java.nio=ALL-UNNAMED
     --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-    --add-opens java.management/sun.management=ALL-UNNAMED 
+    --add-opens java.management/sun.management=ALL-UNNAMED
     --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
 
 # Folio specific
@@ -120,6 +120,7 @@ javaOptions: >-
   -Dpostgres_password=$(OKAPI_DB_PASSWORD)
   -Dpostgres_database=$(OKAPI_DB)
   -Dlog4j.configurationFile=/etc/log4j2.xml
+  -Dlog4j2.formatMsgNoLookups=true
   -Dhost=okapi
   -Dokapiurl=http://okapi:9130
 


### PR DESCRIPTION
Apply fixes based on https://logging.apache.org/log4j/2.x/index.html

Adds the recommended **`-Dlog4j2.formatMsgNoLookups=true`** flag.

(Also, my code editor did some automatic whitespace removal.)